### PR TITLE
Checking lengths beforehand; using while rather than for to return early

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,15 @@ module.exports = function (a, b) {
 		throw new TypeError('Arguments must be Buffers');
 	}
 
-	var ret = 0;
-
-	for (var i = 0; i < a.length; i++) {
-		ret |= a[i] ^ b[i];
+	if (a.length !== b.length) {
+		return false;
 	}
 
-	return a.length === b.length && ret === 0;
+	var length = a.length;
+	var i = 0;
+	while (i < length && a[i] === b[i]) {
+		++i;
+	}
+
+	return (i === length);
 };


### PR DESCRIPTION
This would be my version. Rationale:
- If the lengths differ, there's no point in iterating over the buffer contents.
- As soon as a byte (or unit or whatever) differs, we can stop looping and return false.

The exact same logic applies to strings.
