### PR TITLE
Constant time equality for undersized Buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,16 @@
 'use strict';
-module.exports = function (a, b) {
+module.exports = function (a, b, minComp) {
 	if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
 		throw new TypeError('Arguments must be Buffers');
 	}
 
+	var len = Math.max(a.length, b.length, minComp || 0);
 	var ret = 0;
 
-	for (var i = 0; i < a.length; i++) {
+	for (var i = 0; i < len; i++) {
 		ret |= a[i] ^ b[i];
 	}
+	ret |= a.length ^ b.length;
 
-	return a.length === b.length && ret === 0;
+	return ret === 0;
 };

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,14 @@ bufferEqualsConstant(new Buffer('foo'), new Buffer('foo'));
 
 bufferEqualsConstant(new Buffer('foo'), new Buffer('bar'));
 //=> false
+
+bufferEqualsConstant(new Buffer('foo'), new Buffer('foo'), 512);
+//=> true
 ```
 
 ## API
 
-### bufferEqualsConstant(a, b)
+### bufferEqualsConstant(a, b, [minComp])
 
 Returns a boolean of whether `a` and `b` have the same bytes.
 
@@ -39,6 +42,31 @@ Buffer to compare.
 Type: `Buffer`
 
 Buffer to compare.
+
+#### minComp
+
+Type: `number`
+
+Default: `Math.max(a.length, b.length)`
+
+Minimal number of comparisons used to determine equality.
+
+If the length of `a` or `b` depends on the input of your algorithm, a [possible attacker](https://en.wikipedia.org/wiki/Timing_attack) may gain information about these lengths by varying the input:
+
+```js
+var secret = Buffer('secret');
+bufferEqualsConstant(input, secret);
+```
+
+Based on the execution time of different `input.length` an attacker may discover `secret.length === 6`, because `bufferEqualsConstant` will perform the same number of operations for all `input` with `0 <= input.length <= secret.length`, but needs more operations if `input.length > secret.length`.
+
+To alleviate this problem `minComp` can be used:
+
+```js
+bufferEqualsConstant(input, Buffer('secret'), 1024);
+```
+
+NB: execution time also depends on many optimizations (e.g. [Branch Prediction](http://stackoverflow.com/questions/11227809/why-is-processing-a-sorted-array-faster-than-an-unsorted-array/11227902#11227902)), which could not be completely eliminated with `minComp`.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,24 @@ bufferEqualsConstant(new Buffer('foo'), new Buffer('bar'));
 //=> false
 ```
 
+## API
+
+### bufferEqualsConstant(a, b)
+
+Returns a boolean of whether `a` and `b` have the same bytes.
+
+#### a
+
+Type: `Buffer`
+
+Buffer to compare.
+
+#### b
+
+Type: `Buffer`
+
+Buffer to compare.
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -15,3 +15,27 @@ test(t => {
 	t.throws(() => fn(new Buffer(1), 'abc'));
 	t.end();
 });
+
+test('constant time', t => {
+	const a1 = new Buffer('abcde');
+	const a2 = new Buffer('abcde');
+	const b1 = new Buffer('abcdef');
+	const c1 = new Buffer('abcdeg');
+
+	t.true(fn(a1, a2, 0));
+	t.true(fn(a1, a2, a1.length));
+	t.true(fn(a1, a2, a1.length + 1));
+
+	t.false(fn(a1, b1, 0));
+	t.false(fn(a1, b1, a1.length));
+	t.false(fn(a1, b1, a1.length + 1));
+
+	t.false(fn(b1, c1, 0));
+	t.false(fn(b1, c1, b1.length - 1));
+	t.false(fn(b1, c1, b1.length));
+	t.false(fn(b1, c1, b1.length + 1));
+
+	t.true(fn(new Buffer('foo'), new Buffer('foo'), 512));
+
+	t.end();
+});


### PR DESCRIPTION
The optional `minComp` parameter allows _real_ constant run-time (iff `minComp >= Math.max(buf.length, otherBuf.length)`) and would justify the project naming.
