### PR TITLE
Test against newer Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 'stable'
-  - '0.12'
-  - '0.10'
+  - 8
+  - 6
+  - 4

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "attack"
   ],
   "devDependencies": {
-    "ava": "*",
-    "xo": "*"
+    "ava": "0.22.0",
+    "xo": "0.12.1"
   }
 }


### PR DESCRIPTION
Updates travis.yml, nails down test dependencies:

- `xo` is now set to the version that was released the last time the project was updated
- `ava` is now set to the current latest version (as of time of writing).